### PR TITLE
Allow image selection for arbitrary sizes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -95,7 +95,7 @@ class ImageSelector:
 
         if selected_index:
             print(f"ImageSelector: selected: {len(selected_index)} images")
-            return (images[selected_index, :, :, :], )
+            return (images[selected_index], )
 
         print(f"ImageSelector: selected no images, passthrough")
         return (images, )


### PR DESCRIPTION
Sometime it's necessary to select from other types of outputs than the usual image outputs.

This has been tested to work with [Separate Mask Components](https://github.com/BadCafeCode/masquerade-nodes-comfyui?tab=readme-ov-file#separate-mask-components)